### PR TITLE
Add nightly workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,3 +164,29 @@ workflows:
       - stylish-haskell:
           requires:
             - build
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 8 * * *"  # midnight PST
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - prebuild
+      - build:
+          requires:
+            - prebuild
+      - unit-tests:
+          requires:
+            - build
+      - integration-tests:
+          requires:
+            - build
+      - hlint:
+          requires:
+            - build
+      - stylish-haskell:
+          requires:
+            - build


### PR DESCRIPTION
Since we have QuickCheck tests, we should run nightly so that more random tests are run and can report failures more often