### PR TITLE
Defaults

### DIFF
--- a/src/Database/Persist/Migration/Operation/Types.hs
+++ b/src/Database/Persist/Migration/Operation/Types.hs
@@ -128,10 +128,19 @@ validateColumn col@Column{..} = when (hasDuplicateConstrs colProps) $
 
 -- | A property for a 'Column'.
 data ColumnProp
-  = NotNull -- ^ Makes a column non-nullable (defaults to nullable)
-  | References ColumnIdentifier -- ^ Mark this column as a foreign key to the given column
-  | AutoIncrement -- ^ Makes a column auto-incrementing
-  | Default PersistValue -- ^ Sets the default value for the column
+  = NotNull
+    -- ^ Makes a column non-nullable (defaults to nullable)
+  | References ColumnIdentifier
+    -- ^ Mark this column as a foreign key to the given column
+  | AutoIncrement
+    -- ^ Makes a column auto-incrementing
+  | Default PersistValue
+    -- ^ Sets the default value for the column. Note that this doesn't matter when inserting
+    -- data via Haskell; this property only sets the schema in the SQL backend.
+    --
+    -- See 'AddColumn' for setting the default value for existing rows in a migration.
+    --
+    -- More info: https://www.yesodweb.com/book/persistent#persistent_attributes
   deriving (Show,Eq,Data)
 
 deriving instance Data PersistValue

--- a/src/Database/Persist/Migration/Operation/Types.hs
+++ b/src/Database/Persist/Migration/Operation/Types.hs
@@ -12,6 +12,8 @@ Defines the data types that can be used in Operations.
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Database.Persist.Migration.Operation.Types
   ( -- * Core operations
@@ -40,7 +42,7 @@ import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Database.Persist.Migration.Utils.Data (hasDuplicateConstrs)
-import Database.Persist.Sql (PersistValue, SqlPersistT)
+import Database.Persist.Sql (PersistValue(..), SqlPersistT)
 import Database.Persist.Types (SqlType)
 
 -- | An operation to create a table according to the specified schema.
@@ -129,7 +131,10 @@ data ColumnProp
   = NotNull -- ^ Makes a column non-nullable (defaults to nullable)
   | References ColumnIdentifier -- ^ Mark this column as a foreign key to the given column
   | AutoIncrement -- ^ Makes a column auto-incrementing
+  | Default PersistValue -- ^ Sets the default value for the column
   deriving (Show,Eq,Data)
+
+deriving instance Data PersistValue
 
 -- | Table constraints in a CREATE query.
 data TableConstraint

--- a/src/Database/Persist/Migration/Postgres.hs
+++ b/src/Database/Persist/Migration/Postgres.hs
@@ -143,6 +143,7 @@ showColumnProp = \case
   NotNull -> "NOT NULL"
   References (tab, col) -> "REFERENCES " <> quote tab <> "(" <> quote col <> ")"
   AutoIncrement -> ""
+  Default v -> "DEFAULT " <> showValue v
 
 -- | Show a `TableConstraint`.
 showTableConstraint :: TableConstraint -> Text

--- a/src/Database/Persist/Migration/Postgres.hs
+++ b/src/Database/Persist/Migration/Postgres.hs
@@ -39,7 +39,7 @@ import Database.Persist.Migration
 import qualified Database.Persist.Migration.Core as Migration
 import Database.Persist.Migration.Utils.Sql
     (quote, showValue, uncommas, uncommas')
-import Database.Persist.Sql (SqlPersistT, SqlType(..))
+import Database.Persist.Sql (PersistValue, SqlPersistT, SqlType(..))
 
 -- | Run a migration with the Postgres backend.
 runMigration :: MigrateSettings -> Migration -> SqlPersistT IO ()
@@ -89,16 +89,20 @@ addColumn' :: AddColumn -> SqlPersistT IO [Text]
 addColumn' AddColumn{..} = return $ createQuery : maybeToList alterQuery
   where
     Column{..} = column
+    withoutDefault = column { colProps = filter (not . isDefault) colProps }
     alterTable = "ALTER TABLE " <> quote table <> " "
     -- The CREATE query with the default specified by AddColumn{colDefault}
-    createQuery = alterTable <> "ADD COLUMN " <> showColumn column <> createDefault
+    createQuery = alterTable <> "ADD COLUMN " <> showColumn withoutDefault <> createDefault
     createDefault = case colDefault of
       Nothing -> ""
       Just def -> " DEFAULT " <> showValue def
-    -- The ALTER query to drop the default (if colDefault was set)
-    setJust v = fmap $ const v
+    -- The ALTER query to drop/set the default (if colDefault was set)
     alterQuery =
-      setJust (alterTable <> "ALTER COLUMN " <> quote colName <> " DROP DEFAULT") colDefault
+      let action = case getDefault colProps of
+            Nothing -> "DROP DEFAULT"
+            Just v -> "SET DEFAULT " <> showValue v
+          alterQuery' = alterTable <> "ALTER COLUMN" <> quote colName <> " " <> action
+      in alterQuery' <$ colDefault
 
 dropColumn' :: DropColumn -> SqlPersistT IO [Text]
 dropColumn' DropColumn{..} = return ["ALTER TABLE " <> quote tab <> " DROP COLUMN " <> quote col]
@@ -106,6 +110,17 @@ dropColumn' DropColumn{..} = return ["ALTER TABLE " <> quote tab <> " DROP COLUM
     (tab, col) = column
 
 {- Helpers -}
+
+-- | True if the given ColumnProp sets a default.
+isDefault :: ColumnProp -> Bool
+isDefault (Default _) = True
+isDefault _ = False
+
+-- | Get the default value from the given ColumnProps.
+getDefault :: [ColumnProp] -> Maybe PersistValue
+getDefault [] = Nothing
+getDefault (Default v : _) = Just v
+getDefault (_:props) = getDefault props
 
 -- | Show a 'Column'.
 showColumn :: Column -> Text

--- a/test/integration/Migration.hs
+++ b/test/integration/Migration.hs
@@ -143,14 +143,20 @@ manualMigration =
 testMigrations :: FilePath -> MigrateBackend -> IO (Pool SqlBackend) -> TestTree
 testMigrations dir backend getPool = testGroup "goldens"
   [ testMigration' "Migrate from empty" 0 []
-  , testMigration' "Migrate with v1 person" 1 [insertPerson "David" []]
+  , testMigration' "Migrate with v1 person" 1
+      [ insertPerson "David" []
+      ]
   , testMigration' "Migrate from sex to gender" 2
       [ insertPerson "David" [("sex", "0")]
       , insertPerson "Elizabeth" [("sex", "1")]
       , insertPerson "Foster" [("sex", "NULL")]
       ]
-  , testMigration' "Migrate with default colorblind" 4 [insertPerson "David" []]
-  , testMigration' "Migrations are idempotent" 5 [insertPerson "David" [("colorblind", "TRUE")]]
+  , testMigration' "Migrate with default colorblind" 4
+      [ insertPerson "David" []
+      ]
+  , testMigration' "Migrations are idempotent" (length manualMigration)
+      [ insertPerson "David" [("colorblind", "TRUE")]
+      ]
   ]
   where
     testMigration' = testMigration dir backend getPool

--- a/test/utils/Utils/QuickCheck.hs
+++ b/test/utils/Utils/QuickCheck.hs
@@ -79,8 +79,11 @@ genColumn tableNames = do
 
   autoIncrement <- arbitrarySingleton 1 AutoIncrement
   notNull <- arbitrarySingleton 50 NotNull
+  colDefault <- case autoIncrement of
+    [] -> arbitrarySingleton 10 . Default =<< genPersistValue colType
+    _ -> return []
 
-  let colProps = notNull ++ autoIncrement ++ references
+  let colProps = notNull ++ autoIncrement ++ references ++ colDefault
 
   return Column{..}
   where


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

Fixes #45 

Note that this is only useful for setting the schema in the backend, since the `default` attribute in Persistent [doesn't do much for Haskell insertions](https://www.yesodweb.com/book/persistent#persistent_attributes). Setting the default for existing rows occurs in `AddColumn` already.