### PR TITLE
Fix build for stackage lts 16.16

### DIFF
--- a/src/Database/Persist/Migration.hs
+++ b/src/Database/Persist/Migration.hs
@@ -40,7 +40,7 @@ hasMigration = fmap (not . null) . Persistent.showMigration
 checkMigration :: MonadIO m => Persistent.Migration -> Persistent.SqlPersistT m ()
 checkMigration migration = do
   migrationText <- Persistent.showMigration migration
-  unless (null migrationText) $ fail $
+  unless (null migrationText) $ error $
     unlines $ "More migrations detected:" : bullets migrationText
   where
     bullets = map ((" * " ++ ) . Text.unpack)

--- a/src/Database/Persist/Migration/Core.hs
+++ b/src/Database/Persist/Migration/Core.hs
@@ -163,12 +163,12 @@ getMigration :: MonadIO m
   -> Migration
   -> SqlPersistT m [MigrateSql]
 getMigration backend _ migration = do
-  either fail return $ validateMigration migration
+  either error return $ validateMigration migration
   currVersion <- getCurrVersion backend
   operations <- either badPath return $ getOperations migration currVersion
-  either fail return $ mapM_ validateOperation operations
+  either error return $ mapM_ validateOperation operations
   concatMapM (mapReaderT liftIO . getMigrationSql backend) operations
   where
-    badPath (start, end) = fail $ "Could not find path: " ++ show start ++ " ~> " ++ show end
+    badPath (start, end) = error $ "Could not find path: " ++ show start ++ " ~> " ++ show end
     -- Utilities
     concatMapM f = fmap concat . mapM f

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,6 @@
-resolver: lts-11.11
+resolver: lts-16.16
 install-ghc: true
 
 packages:
 - .
 
-extra-deps:
-# until 2.1.6 released
-- git: https://github.com/ndmitchell/hlint
-  commit: 749179b88e6c92b4e9e9f6e55da30012cd158536
-- tasty-golden-2.3.2

--- a/test/integration/Migration.hs
+++ b/test/integration/Migration.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -8,8 +9,10 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-unused-top-binds #-}
 
 module Migration (testMigrations) where

--- a/test/utils/Utils/QuickCheck.hs
+++ b/test/utils/Utils/QuickCheck.hs
@@ -171,7 +171,7 @@ genPersistValue = \case
   SqlTime -> PersistTimeOfDay <$> arbitrary
   SqlDayTime -> PersistUTCTime <$> arbitrary
   SqlBlob -> PersistByteString . ByteString.map cleanText <$> arbitrary
-  SqlOther _ -> fail "SqlOther not supported"
+  SqlOther _ -> error "SqlOther not supported"
   where
     cleanDouble :: Double -> Double
     cleanDouble x = if isInfinite x || isNaN x then 0 else x


### PR DESCRIPTION
Hi there,

i am not educated about the background of the changes in GHC and base libs that lead to these missing `MonadFail` instance errors that occur on latest stackage LTS 16.16.

As i need this library for another project that i would like to update stackage in, i am interested in this library compiling again.

Are these fixes ok or is it too much of a hack?